### PR TITLE
Reduced dependency hierarchy

### DIFF
--- a/src/FunStripe.fsproj
+++ b/src/FunStripe.fsproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="9.0.101" />
-    <PackageReference Include="FSharp.Data" Version="6.4.1" />
+    <PackageReference Include="FSharp.Data.Json.Core" Version="6.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
   </ItemGroup>

--- a/src/FunStripeLite/FunStripeLite.fsproj
+++ b/src/FunStripeLite/FunStripeLite.fsproj
@@ -38,6 +38,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="9.0.101" />
-    <PackageReference Include="FSharp.Data" Version="6.4.1" />
+    <PackageReference Include="FSharp.Data.Json.Core" Version="6.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Because FunStripe and FunStripeLite only use FSharp.Data JSON structures and utilities, it doesn't have to load the full FSharp.Data type-provider features, instead it can use only one of the FSharp.Data dependency packages called FSharp.Data.Json.Core.
