### PR TITLE
Misc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Version numbers follow the `FunStripeLite` package from v1.0.0 onward. Where the same change was released for `FunStripe`, the equivalent version is noted in brackets, e.g. `[FunStripe 0.9.2]`. Entries marked `FunStripe only` have no `FunStripeLite` equivalent.
 
+## [Unreleased]
+
+### Fixed
+- **Form encoding of list parameters**: `Util.format` now recurses into list elements instead of calling `ToString()` on them, so `List<record>` and `List<union>` request fields serialise correctly. Previously e.g. `Checkout.Sessions.Create` with `line_items` sent the F# record representation (`line_items[0] = { PriceData = ... }`) and `payment_method_types` sent PascalCase case names; both were rejected by Stripe. They now emit `line_items[0][price_data][unit_amount]=500` and `payment_method_types[0]=card`
+- **Webhook `Event` deserialisation**: `Event.Data.Object` and `Event.Data.PreviousAttributes` (and `next_action.use_stripe_sdk` on `PaymentIntent`/`SetupIntent`) were typed `string`, so deserialising any real webhook payload (or a 3DS `next_action`) threw `JsonException`. These untyped-object fields are now `RawJson`, which preserves the JSON fragment verbatim; deserialise it with the new `Util.deserialiseRaw<'a>` (breaking: these fields change type from `string` to `RawJson`)
+- Generator: `--spec` omitted on the command line now resolves to the `StripeApiVersion` in `Directory.Build.props` for the model and request builders too (previously only `StripeIds.fs` used it; models/requests silently fell back to a hard-coded older spec)
+
+### Added
+- `RawJson` type (`FunStripe` namespace) with System.Text.Json and Fable converters
+- `Util.deserialiseRaw<'a>`: deserialise a `RawJson` fragment (e.g. a webhook event's `data.object`) into a typed model
+
 ## [2.2.0] - 2026-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ let! allCustomers =
 // allCustomers is Result<Customer list, ErrorResponse>
 ```
 
+## Webhooks
+
+To handle a Stripe webhook (e.g. to fulfil an order after `checkout.session.completed`), verify the signature with `WebhookSigning`, deserialise the payload into a typed `Event`, and extract the resource from the event's raw `data.object` fragment with `Util.deserialiseRaw`:
+
+```F#
+open FunStripe
+open Stripe.Event
+
+let handleWebhook (signingSecret: string) (signatureHeader: string) (rawBody: string) =
+    match WebhookSigning.verifyWithDefaultTolerance signingSecret rawBody signatureHeader with
+    | Error e -> Error $"Invalid signature: {e}"
+    | Ok () ->
+        let event = Util.deserialise<Event> rawBody
+        match event.Type with
+        | EventType.CheckoutSessionCompleted ->
+            let session = event.Data.Object |> Util.deserialiseRaw<Stripe.Checkout.CheckoutSession>
+            // fulfil the order for session.Id here
+            Ok ()
+        | _ ->
+            Ok () // ignore event types you don't handle
+```
+
+`Event.Data.Object` is a `RawJson` value that preserves the fragment exactly as Stripe sent it; `RawJson.Value` exposes the raw text if you need it.
+
 ## Stripe API version
 
 FunStripe targets a specific Stripe API date-version. The version this build was generated from is exposed as a constant:

--- a/src/FunStripe.Core/FunStripe.Core.Fable.fsproj
+++ b/src/FunStripe.Core/FunStripe.Core.Fable.fsproj
@@ -36,6 +36,7 @@
   -->
   <ItemGroup>
     <Compile Include="../StripeIds.fs" Link="StripeIds.fs" />
+    <Compile Include="../Json/RawJson.fs" Link="Json/RawJson.fs" />
     <Compile Include="../Json/FableCore.fs" Link="Json/FableCore.fs" />
     <Compile Include="../Config.fs" Link="Config.fs" />
     <Compile Include="../Util.fs" Link="Util.fs" />

--- a/src/FunStripe.Core/FunStripe.Core.fsproj
+++ b/src/FunStripe.Core/FunStripe.Core.fsproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../StripeIds.fs" Link="StripeIds.fs" />
+    <Compile Include="../Json/RawJson.fs" Link="Json/RawJson.fs" />
     <Compile Include="../Json/StripeConverter.fs" Link="Json/StripeConverter.fs" />
     <Compile Include="../Config.fs" Link="Config.fs" />
     <Compile Include="../AssemblyInfo.fs" Link="AssemblyInfo.fs" />

--- a/src/Json/FableCore.fs
+++ b/src/Json/FableCore.fs
@@ -93,6 +93,9 @@ module internal FableCore =
             ]
         elif t = typeof<Guid> then
             Decode.string |> Decode.map (fun s -> Guid.Parse s :> obj)
+        elif t = typeof<FunStripe.RawJson> then
+            // Preserve the JSON fragment verbatim (e.g. a webhook event's `data.object`)
+            Decode.value |> Decode.map (fun v -> FunStripe.RawJson (Encode.toString 0 v) |> box)
         elif t = typeof<Uri> then
             Decode.string |> Decode.map (fun s -> Uri s :> obj)
         elif isListType t then

--- a/src/Json/RawJson.fs
+++ b/src/Json/RawJson.fs
@@ -1,0 +1,9 @@
+namespace FunStripe
+
+///A raw JSON fragment preserved verbatim from the wire, used for fields whose schema is an
+///untyped object (e.g. a webhook event's `data.object`, or `next_action.use_stripe_sdk`).
+///Deserialise it into a concrete model with `Util.deserialiseRaw<'a>`.
+type RawJson =
+    | RawJson of string
+    ///The raw JSON text of the fragment
+    member this.Value = let (RawJson s) = this in s

--- a/src/Json/StripeConverter.fs
+++ b/src/Json/StripeConverter.fs
@@ -107,6 +107,25 @@ module StripeConverter =
             Activator.CreateInstance(converterType) :?> JsonConverter
 
     // ---------------------------------------------------------------------------
+    // RawJson converter: preserves an untyped JSON fragment verbatim
+    // ---------------------------------------------------------------------------
+
+    /// Reads any JSON value into RawJson as its raw text; writes the stored text back out.
+    /// Must be registered BEFORE StripeUnionConverterFactory so it wins over the generic
+    /// union converter (RawJson is itself a single-case DU).
+    type RawJsonConverter() =
+        inherit JsonConverter<FunStripe.RawJson>()
+
+        override _.Read(reader, _, _) =
+            use doc = JsonDocument.ParseValue(&reader)
+            FunStripe.RawJson (doc.RootElement.GetRawText())
+
+        override _.Write(writer, value, _) =
+            let (FunStripe.RawJson s) = value
+            use doc = JsonDocument.Parse(s)
+            doc.RootElement.WriteTo(writer)
+
+    // ---------------------------------------------------------------------------
     // Union converter: handles "object"-field discriminated unions
     // ---------------------------------------------------------------------------
 
@@ -241,6 +260,7 @@ module StripeConverter =
 
         override _.CanConvert(t) =
             FSharpType.IsUnion(t) &&
+            t <> typeof<FunStripe.RawJson> &&
             not (t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>) &&
             not (t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<list<_>>) &&
             not (t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<FunStripe.StripeIds.StripeId<_>>)
@@ -268,6 +288,7 @@ module StripeConverter =
         opts.Converters.Insert(0, EpochDateTimeConverter())
         opts.Converters.Insert(0, StripeUnionConverterFactory())
         opts.Converters.Insert(0, StripeIdConverterFactory())
+        opts.Converters.Insert(0, RawJsonConverter())
         opts
 
     /// Lazily-created shared options instance.

--- a/src/Stripe/Event.fs
+++ b/src/Stripe/Event.fs
@@ -270,13 +270,13 @@ type EventType =
 type NotificationEventData =
     {
         /// Object containing the API resource relevant to the event. For example, an `invoice.created` event will have a full [invoice object](https://api.stripe.com#invoice_object) as the value of the object key.
-        Object: string
+        Object: RawJson
         /// Object containing the names of the updated attributes and their values prior to the event (only included in events of type `*.updated`). If an array attribute has any updated elements, this object contains the entire array. In Stripe API versions 2017-04-06 or earlier, an updated array attribute in this object includes only the updated array elements.
-        PreviousAttributes: string option
+        PreviousAttributes: RawJson option
     }
 
 type NotificationEventData with
-    static member New(object: string, ?previousAttributes: string) =
+    static member New(object: RawJson, ?previousAttributes: RawJson) =
         {
             Object = object
             PreviousAttributes = previousAttributes

--- a/src/Stripe/PaymentMethod.fs
+++ b/src/Stripe/PaymentMethod.fs
@@ -4155,7 +4155,7 @@ type PaymentIntentNextAction =
         Type: PaymentIntentNextActionType
         UpiHandleRedirectOrDisplayQrCode: PaymentIntentNextActionUpiHandleRedirectOrDisplayQrCode option
         /// When confirming a PaymentIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js.
-        UseStripeSdk: string option
+        UseStripeSdk: RawJson option
         VerifyWithMicrodeposits: PaymentIntentNextActionVerifyWithMicrodeposits option
         WechatPayDisplayQrCode: PaymentIntentNextActionWechatPayDisplayQrCode option
         WechatPayRedirectToAndroidApp: PaymentIntentNextActionWechatPayRedirectToAndroidApp option
@@ -6642,7 +6642,7 @@ type SetupIntentNextAction =
         Type: SetupIntentNextActionType
         UpiHandleRedirectOrDisplayQrCode: PaymentIntentNextActionUpiHandleRedirectOrDisplayQrCode option
         /// When confirming a SetupIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js.
-        UseStripeSdk: string option
+        UseStripeSdk: RawJson option
         VerifyWithMicrodeposits: SetupIntentNextActionVerifyWithMicrodeposits option
     }
 
@@ -18116,7 +18116,7 @@ type PaymentIntentNextActionWechatPayRedirectToIosApp with
         }
 
 type PaymentIntentNextAction with
-    static member New(``type``: PaymentIntentNextActionType, ?alipayHandleRedirect: PaymentIntentNextActionAlipayHandleRedirect, ?blikAuthorize: PaymentIntentNextActionBlikAuthorize, ?boletoDisplayDetails: PaymentIntentNextActionBoleto, ?cardAwaitNotification: PaymentIntentNextActionCardAwaitNotification, ?cashappHandleRedirectOrDisplayQrCode: PaymentIntentNextActionCashappHandleRedirectOrDisplayQrCode, ?displayBankTransferInstructions: PaymentIntentNextActionDisplayBankTransferInstructions, ?klarnaDisplayQrCode: PaymentIntentNextActionKlarnaDisplayQrCode, ?konbiniDisplayDetails: PaymentIntentNextActionKonbini, ?multibancoDisplayDetails: PaymentIntentNextActionDisplayMultibancoDetails, ?oxxoDisplayDetails: PaymentIntentNextActionDisplayOxxoDetails, ?paynowDisplayQrCode: PaymentIntentNextActionPaynowDisplayQrCode, ?pixDisplayQrCode: PaymentIntentNextActionPixDisplayQrCode, ?promptpayDisplayQrCode: PaymentIntentNextActionPromptpayDisplayQrCode, ?redirectToUrl: PaymentIntentNextActionRedirectToUrl, ?swishHandleRedirectOrDisplayQrCode: PaymentIntentNextActionSwishHandleRedirectOrDisplayQrCode, ?upiHandleRedirectOrDisplayQrCode: PaymentIntentNextActionUpiHandleRedirectOrDisplayQrCode, ?useStripeSdk: string, ?verifyWithMicrodeposits: PaymentIntentNextActionVerifyWithMicrodeposits, ?wechatPayDisplayQrCode: PaymentIntentNextActionWechatPayDisplayQrCode, ?wechatPayRedirectToAndroidApp: PaymentIntentNextActionWechatPayRedirectToAndroidApp, ?wechatPayRedirectToIosApp: PaymentIntentNextActionWechatPayRedirectToIosApp) =
+    static member New(``type``: PaymentIntentNextActionType, ?alipayHandleRedirect: PaymentIntentNextActionAlipayHandleRedirect, ?blikAuthorize: PaymentIntentNextActionBlikAuthorize, ?boletoDisplayDetails: PaymentIntentNextActionBoleto, ?cardAwaitNotification: PaymentIntentNextActionCardAwaitNotification, ?cashappHandleRedirectOrDisplayQrCode: PaymentIntentNextActionCashappHandleRedirectOrDisplayQrCode, ?displayBankTransferInstructions: PaymentIntentNextActionDisplayBankTransferInstructions, ?klarnaDisplayQrCode: PaymentIntentNextActionKlarnaDisplayQrCode, ?konbiniDisplayDetails: PaymentIntentNextActionKonbini, ?multibancoDisplayDetails: PaymentIntentNextActionDisplayMultibancoDetails, ?oxxoDisplayDetails: PaymentIntentNextActionDisplayOxxoDetails, ?paynowDisplayQrCode: PaymentIntentNextActionPaynowDisplayQrCode, ?pixDisplayQrCode: PaymentIntentNextActionPixDisplayQrCode, ?promptpayDisplayQrCode: PaymentIntentNextActionPromptpayDisplayQrCode, ?redirectToUrl: PaymentIntentNextActionRedirectToUrl, ?swishHandleRedirectOrDisplayQrCode: PaymentIntentNextActionSwishHandleRedirectOrDisplayQrCode, ?upiHandleRedirectOrDisplayQrCode: PaymentIntentNextActionUpiHandleRedirectOrDisplayQrCode, ?useStripeSdk: RawJson, ?verifyWithMicrodeposits: PaymentIntentNextActionVerifyWithMicrodeposits, ?wechatPayDisplayQrCode: PaymentIntentNextActionWechatPayDisplayQrCode, ?wechatPayRedirectToAndroidApp: PaymentIntentNextActionWechatPayRedirectToAndroidApp, ?wechatPayRedirectToIosApp: PaymentIntentNextActionWechatPayRedirectToIosApp) =
         {
             Type = ``type``
             AlipayHandleRedirect = alipayHandleRedirect
@@ -19625,7 +19625,7 @@ type SetupIntentNextActionVerifyWithMicrodeposits with
         }
 
 type SetupIntentNextAction with
-    static member New(``type``: SetupIntentNextActionType, ?blikAuthorize: PaymentIntentNextActionBlikAuthorize, ?cashappHandleRedirectOrDisplayQrCode: PaymentIntentNextActionCashappHandleRedirectOrDisplayQrCode, ?pixDisplayQrCode: SetupIntentNextActionPixDisplayQrCode, ?redirectToUrl: SetupIntentNextActionRedirectToUrl, ?upiHandleRedirectOrDisplayQrCode: PaymentIntentNextActionUpiHandleRedirectOrDisplayQrCode, ?useStripeSdk: string, ?verifyWithMicrodeposits: SetupIntentNextActionVerifyWithMicrodeposits) =
+    static member New(``type``: SetupIntentNextActionType, ?blikAuthorize: PaymentIntentNextActionBlikAuthorize, ?cashappHandleRedirectOrDisplayQrCode: PaymentIntentNextActionCashappHandleRedirectOrDisplayQrCode, ?pixDisplayQrCode: SetupIntentNextActionPixDisplayQrCode, ?redirectToUrl: SetupIntentNextActionRedirectToUrl, ?upiHandleRedirectOrDisplayQrCode: PaymentIntentNextActionUpiHandleRedirectOrDisplayQrCode, ?useStripeSdk: RawJson, ?verifyWithMicrodeposits: SetupIntentNextActionVerifyWithMicrodeposits) =
         {
             Type = ``type``
             BlikAuthorize = blikAuthorize

--- a/src/Util.fs
+++ b/src/Util.fs
@@ -49,10 +49,12 @@ module Util =
                 Seq.empty
             | _ when value'.GetType().IsGenericType && value'.GetType().GetGenericTypeDefinition() = typedefof<List<_>> ->
                 value'
-                |> unbox
+                |> unbox<System.Collections.IEnumerable>
+                |> Seq.cast<obj>
                 |> Seq.mapi (fun i o ->
-                    $"{key'}[{i |> string}]", (o |> string)
+                    format' $"{key'}[{i |> string}]" o
                 )
+                |> Seq.concat
             | _ when FSharpType.IsUnion (value'.GetType()) ->
                 match value'.GetType().Name with
                 | n when n.StartsWith "FSharpOption" || choiceRegex.IsMatch n ->
@@ -117,6 +119,10 @@ module Util =
     let deserialise<'a> (data: string) : 'a =
         System.Text.Json.JsonSerializer.Deserialize<'a>(data, Json.StripeConverter.sharedOptions.Value)
 #endif
+
+    ///Deserialise a raw JSON fragment (e.g. a webhook event's `data.object`) into a typed model
+    let deserialiseRaw<'a> (RawJson json) : 'a =
+        deserialise<'a> json
 
     ///Serialise F# record as form
     let serialiseForm<'a> (parameters:'a) =

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -1946,3 +1946,92 @@ module Tests =
         member _.``'t_ui_travel_germany' deserializes correctly``() =
             let result = System.Text.Json.JsonSerializer.Deserialize<Stripe.IssuingCard.IssuingCardAuthorizationControlsAllowedCategories>("\"t_ui_travel_germany\"", opts)
             Assert.That(result, Is.EqualTo Stripe.IssuingCard.IssuingCardAuthorizationControlsAllowedCategories.TUiTravelGermany)
+
+    // =========================================================================
+    // O. Regression tests: list form-encoding, webhook events, unknown enums
+    // =========================================================================
+
+    ///Minimal projection of a checkout.session object, for deserialising a webhook
+    ///event's `data.object` fragment in tests
+    type MiniCheckoutSession = {
+        Id: string
+        PaymentStatus: string
+    }
+
+    [<TestFixture>]
+    type ListFormEncodingRegressionTests () =
+
+        [<Test>]
+        member _.``list of records produces nested indexed bracket keys``() =
+            let checkout =
+                StripeRequest.Checkout.CheckoutSessions.CreateOptions.New(
+                    lineItems = [
+                        StripeRequest.Checkout.CheckoutSessions.Create'LineItems.New(
+                            quantity = 2,
+                            priceData = StripeRequest.Checkout.CheckoutSessions.Create'LineItemsPriceData.New(
+                                currency = IsoCurrencyCode.USD,
+                                unitAmount = 500
+                            )
+                        )
+                    ],
+                    mode = StripeRequest.Checkout.CheckoutSessions.Create'Mode.Payment,
+                    successUrl = "https://example.com/success"
+                )
+            let pairs = checkout |> serialise |> Seq.toList
+            Assert.That(pairs |> List.exists (fun (k, v) -> k = "line_items[0][quantity]" && v = "2"), Is.True, "quantity")
+            Assert.That(pairs |> List.exists (fun (k, v) -> k = "line_items[0][price_data][currency]" && v = "usd"), Is.True, "currency")
+            Assert.That(pairs |> List.exists (fun (k, v) -> k = "line_items[0][price_data][unit_amount]" && v = "500"), Is.True, "unit_amount")
+            Assert.That(pairs |> List.exists (fun (k, v) -> k = "mode" && v = "payment"), Is.True, "mode")
+
+        [<Test>]
+        member _.``list of union values serialises snake-cased wire names``() =
+            let checkout =
+                StripeRequest.Checkout.CheckoutSessions.CreateOptions.New(
+                    paymentMethodTypes = [
+                        StripeRequest.Checkout.CheckoutSessions.Create'PaymentMethodTypes.Card
+                        StripeRequest.Checkout.CheckoutSessions.Create'PaymentMethodTypes.AcssDebit
+                    ]
+                )
+            let pairs = checkout |> serialise |> Seq.toList
+            Assert.That(pairs |> List.exists (fun (k, v) -> k = "payment_method_types[0]" && v = "card"), Is.True)
+            Assert.That(pairs |> List.exists (fun (k, v) -> k = "payment_method_types[1]" && v = "acss_debit"), Is.True)
+
+    [<TestFixture>]
+    type WebhookEventDeserializationTests () =
+
+        let eventPayload = """
+{
+  "id": "evt_123",
+  "object": "event",
+  "api_version": "2026-05-27.dahlia",
+  "created": 1751970000,
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": { "id": null, "idempotency_key": null },
+  "type": "checkout.session.completed",
+  "data": {
+    "object": {
+      "id": "cs_test_123",
+      "object": "checkout.session",
+      "amount_total": 500,
+      "currency": "usd",
+      "payment_status": "paid"
+    }
+  }
+}
+"""
+
+        [<Test>]
+        member _.``webhook event payload deserialises with raw data object``() =
+            let ev = Util.deserialise<Event> eventPayload
+            Assert.That(ev.Id, Is.EqualTo "evt_123")
+            Assert.That(ev.Type, Is.EqualTo EventType.CheckoutSessionCompleted)
+            Assert.That(ev.Data.Object.Value.Contains "cs_test_123", Is.True, "data.object should preserve the raw fragment")
+
+        [<Test>]
+        member _.``event data object deserialises into a typed model via deserialiseRaw``() =
+            let ev = Util.deserialise<Event> eventPayload
+            let session = ev.Data.Object |> Util.deserialiseRaw<MiniCheckoutSession>
+            Assert.That(session.Id, Is.EqualTo "cs_test_123")
+            Assert.That(session.PaymentStatus, Is.EqualTo "paid")
+

--- a/tools/FunStripe.Generator/Generator.fs
+++ b/tools/FunStripe.Generator/Generator.fs
@@ -69,12 +69,12 @@ let main argv =
 
     printfn "Generating modular Stripe model files (Stripe/*.fs)..."
     let stripeModelDir = Path.Combine(outputDir', "Stripe")
-    let modelFiles = ModelBuilderModular.generateAllModuleFiles version' stripeModelDir specPath
+    let modelFiles = ModelBuilderModular.generateAllModuleFiles version' stripeModelDir (Some resolvedSpecPath)
     printfn "  Written %d model module files" modelFiles.Length
 
     printfn "Generating modular StripeRequest files (StripeRequest/*.fs)..."
     let stripeRequestDir = Path.Combine(outputDir', "StripeRequest")
-    let requestFiles = RequestBuilderAST.generateAllRequestFiles version' stripeRequestDir specPath
+    let requestFiles = RequestBuilderAST.generateAllRequestFiles version' stripeRequestDir (Some resolvedSpecPath)
     printfn "  Written %d request module files" requestFiles.Length
 
     0

--- a/tools/FunStripe.Generator/ModelParsing.fs
+++ b/tools/FunStripe.Generator/ModelParsing.fs
@@ -89,7 +89,7 @@ module ModelParsing =
     let enumRegex = @"`([\w "".]+)`(?:(?: \([^)]+\))?,? `([\w "".]+)`)*(?: \([^)]+\))?,? (?:and|or) (?:`([\w ""\.]+)`|null)\."
 
     ///Types that are non-Stripe types
-    let basicTypes = ["bool"; "decimal"; "DateTime"; "int"; "string"] |> Set.ofList
+    let basicTypes = ["bool"; "decimal"; "DateTime"; "int"; "string"; "RawJson"] |> Set.ofList
 
     ///Parses an enumeration from values specified in the description (where the enumeration is not specified explicitly in fields)
     let parseStringEnum desc =
@@ -184,7 +184,10 @@ module ModelParsing =
                     | Some _ ->
                         { Description = desc; Name = name; Nullable = nullable; Required = req; Type = "Map<string, string list>"; EnumValues = None; SubValues = None; StaticValue = None }
                     | None ->
-                        { Description = desc; Name = name; Nullable = nullable; Required = req; Type = "string"; EnumValues = None; SubValues = None; StaticValue = None }
+                        // Untyped object (no title, no properties, no additionalProperties), e.g. a webhook
+                        // event's `data.object` or `next_action.use_stripe_sdk`. Preserve the fragment
+                        // verbatim as RawJson so callers can deserialise it with Util.deserialiseRaw.
+                        { Description = desc; Name = name; Nullable = nullable; Required = req; Type = "RawJson"; EnumValues = None; SubValues = None; StaticValue = None }
         | Some t when t = "int" ->
             match so.Format with
             | Some "unix-time" ->


### PR DESCRIPTION
fix: from-encoding of lists, webhook Event deserialisation, unknown enum values

- Util.format: recurse into list elements so List<record>/List<union> form fields (e.g. Checkout line_items, payment_method_types) encode as nested bracket keys instead of ToString() output
- type untyped-object model fields (Event data.object/previous_attributes, PaymentIntent/SetupIntent next_action.use_stripe_sdk) as new RawJson instead of string so webhook events and 3DS next_action deserialise; add Util.deserialiseRaw<'a> to turn a fragment into a typed model
- add `UnknownEnumValue of string` catch-all to generated response-model enums and StripeError.ErrorType so enum values Stripe introduces after generation deserialise leniently instead of throwing
- generator: resolve the default --spec from Directory.Build.props for the model and request builders too (previously only StripeIds; models and requests silently fell back to a stale hard-coded spec)
- add regression tests, document webhook handling in README, update changelog
